### PR TITLE
Add config option, disabled by default, to raise errors when an example that  does not match the expected type is added to the request

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # 0.2.11
 
 - Fix: params in GET requests are now set in querystring instead of body.
+- Add config option, disabled by default, to raise errors when an example that
+  does not match the expected type is added to the request.
 
 # 0.2.10
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ documented types at runtime.
    - [Changing examples file path](#changing-examples-file-path)
    - [Customizing error messages](#customizing-error-messages)
    - [Customizing error serialization](#customizing-error-serialization)
+   - [Raise on inalid response example](#raise-on-invalid-response-example)
 
 # Installation
 
@@ -698,4 +699,11 @@ class ApplicationController < ActionController::API
     render json: { error: "invalid_params", params: err.errors }, status: 422
   end
 end
+```
+
+### Raise on invalid response example
+
+```ruby
+config.raise_on_invalid_response_example = true # default is false
+config.raise_on_invalid_response_example = ::Rails.env.development? # recommended
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ documented types at runtime.
    - [Changing examples file path](#changing-examples-file-path)
    - [Customizing error messages](#customizing-error-messages)
    - [Customizing error serialization](#customizing-error-serialization)
-   - [Raise on inalid response example](#raise-on-invalid-response-example)
+   - [Raise on invalid example](#raise-on-invalid-example)
 
 # Installation
 
@@ -701,9 +701,9 @@ class ApplicationController < ActionController::API
 end
 ```
 
-### Raise on invalid response example
+### Raise on invalid example
 
 ```ruby
-config.raise_on_invalid_response_example = true # default is false
-config.raise_on_invalid_response_example = ::Rails.env.development? # recommended
+config.raise_on_invalid_example = true # default is false
+config.raise_on_invalid_example = ::Rails.env.development? # recommended
 ```

--- a/lib/explicit/configuration.rb
+++ b/lib/explicit/configuration.rb
@@ -28,6 +28,14 @@ module Explicit
       @rescue_from_invalid_params
     end
 
+    def raise_on_invalid_response_example=(enabled)
+      @raise_on_invalid_response_example = enabled
+    end
+
+    def raise_on_invalid_response_example?
+      @raise_on_invalid_response_example
+    end
+
     def test_runner=(test_runner)
       @test_runner = test_runner
     end

--- a/lib/explicit/configuration.rb
+++ b/lib/explicit/configuration.rb
@@ -28,12 +28,12 @@ module Explicit
       @rescue_from_invalid_params
     end
 
-    def raise_on_invalid_response_example=(enabled)
-      @raise_on_invalid_response_example = enabled
+    def raise_on_invalid_example=(enabled)
+      @raise_on_invalid_example = enabled
     end
 
-    def raise_on_invalid_response_example?
-      @raise_on_invalid_response_example
+    def raise_on_invalid_example?
+      @raise_on_invalid_example
     end
 
     def test_runner=(test_runner)

--- a/lib/explicit/documentation.rb
+++ b/lib/explicit/documentation.rb
@@ -14,7 +14,7 @@ module Explicit::Documentation
     end
 
     engine.define_singleton_method(:documentation_builder) { builder }
-    
+
     engine.routes.draw do
       get "/", to: builder.webpage, as: :explicit_documentation_webpage
       get "/swagger", to: builder.swagger, as: :explicit_documentation_swagger

--- a/lib/explicit/request.rb
+++ b/lib/explicit/request.rb
@@ -113,8 +113,15 @@ class Explicit::Request
     response = Response.new(status:, data:)
 
     case responses_type(status:).validate(data)
-    in [:ok, _] then nil
-    in [:error, err] then raise InvalidResponseError.new(response, err)
+    in [:ok, _]
+      nil
+
+    in [:error, err]
+      if ::Explicit.configuration.raise_on_invalid_response_example?
+        raise InvalidResponseError.new(response, err)
+      else
+        ::Rails.logger.error("[Explicit] Invalid response for #{gid} with status #{status}: #{err}")
+      end
     end
 
     @examples[response.status] << Example.new(request: self, params:, headers:, response:)

--- a/lib/explicit/request.rb
+++ b/lib/explicit/request.rb
@@ -117,7 +117,7 @@ class Explicit::Request
       nil
 
     in [:error, err]
-      if ::Explicit.configuration.raise_on_invalid_response_example?
+      if ::Explicit.configuration.raise_on_invalid_example?
         raise InvalidResponseError.new(response, err)
       else
         ::Rails.logger.error("[Explicit] Invalid response for #{gid} with status #{status}: #{err}")

--- a/test/explicit/request/example_test.rb
+++ b/test/explicit/request/example_test.rb
@@ -24,7 +24,7 @@ class Explicit::Request::ExamplesTest < ActiveSupport::TestCase
   end
 
   test "raises an error if example does not match response types" do
-    ::Explicit.configuration.raise_on_invalid_response_example = true
+    ::Explicit.configuration.raise_on_invalid_example = true
 
     assert_raises Explicit::Request::InvalidResponseError do
       Explicit::Request.new do
@@ -37,6 +37,6 @@ class Explicit::Request::ExamplesTest < ActiveSupport::TestCase
       end
     end
   ensure
-    ::Explicit.configuration.raise_on_invalid_response_example = false
+    ::Explicit.configuration.raise_on_invalid_example = false
   end
 end

--- a/test/explicit/request/example_test.rb
+++ b/test/explicit/request/example_test.rb
@@ -24,6 +24,8 @@ class Explicit::Request::ExamplesTest < ActiveSupport::TestCase
   end
 
   test "raises an error if example does not match response types" do
+    ::Explicit.configuration.raise_on_invalid_response_example = true
+
     assert_raises Explicit::Request::InvalidResponseError do
       Explicit::Request.new do
         response 200, {}
@@ -34,5 +36,7 @@ class Explicit::Request::ExamplesTest < ActiveSupport::TestCase
         )
       end
     end
+  ensure
+    ::Explicit.configuration.raise_on_invalid_response_example = false
   end
 end


### PR DESCRIPTION
Fixes #52