### PR TITLE
Fix type checking in `hash` and `record` types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.2.14
+
+- Fix type checking in `hash` and `record` types when value is either a `String` or `Array`.
+
 # 0.2.13
 
 - Fix: params in GET requests are now set in query string instead of body.

--- a/lib/explicit/type/hash.rb
+++ b/lib/explicit/type/hash.rb
@@ -10,7 +10,10 @@ class Explicit::Type::Hash < Explicit::Type
   end
 
   def validate(value)
-    return error_i18n("hash") if !value.respond_to?(:[])
+    if !value.respond_to?(:[]) || value.is_a?(::String) || value.is_a?(::Array)
+      return error_i18n("hash")
+    end
+
     return error_i18n("empty") if value.empty? && empty == false
 
     validated_hash = {}

--- a/lib/explicit/type/record.rb
+++ b/lib/explicit/type/record.rb
@@ -12,7 +12,9 @@ class Explicit::Type::Record < Explicit::Type
   end
 
   def validate(data)
-    return error_i18n("hash") if !data.respond_to?(:[])
+    if !data.respond_to?(:[]) || data.is_a?(::String) || data.is_a?(::Array)
+      return error_i18n("hash") 
+    end
 
     validated_data = {}
     errors = {}

--- a/test/explicit/type/hash_test.rb
+++ b/test/explicit/type/hash_test.rb
@@ -35,6 +35,10 @@ class Explicit::Type::HashTest < ActiveSupport::TestCase
   end
 
   test "error value" do
+    assert_error "must be an object", validate(nil, [:hash, :string, :string])
+    assert_error "must be an object", validate("", [:hash, :string, :string])
+    assert_error "must be an object", validate([], [:hash, :string, :string])
+
     assert_error(
       "invalid value at key (foo): must be an integer",
       validate({ "foo" => "bar" }, [:hash, :string, :integer])

--- a/test/explicit/type/record_test.rb
+++ b/test/explicit/type/record_test.rb
@@ -36,6 +36,8 @@ class Explicit::Type::RecordTest < ActiveSupport::TestCase
 
   test "error" do
     assert_error "must be an object", validate(nil, USER_SCHEMA)
+    assert_error "must be an object", validate("", USER_SCHEMA)
+    assert_error "must be an object", validate([], USER_SCHEMA)
 
     assert_error(
       { age: "must be an integer" },


### PR DESCRIPTION
Fix type checking in `hash` and `record` types for `String` or `Array` values.

The reason we check for `respond_to?(:[])` instead of `is_a?(::Hash)` is to support Rails' request params and other hash-like interfaces.