### PR TITLE
[Swagger] CORs support + fix link to swagger UI when `default_url_options` is not set

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 0.2.15
+
+- Add preflight request to /swagger endpoint to fix CORS issues with swagger UI.
+- Use same host present in the webpage request instead of the hots defined in
+  `routes.default_url_options`
+
 # 0.2.14
 
 - Fix type checking in `hash` and `record` types when value is either a `String` or `Array`.

--- a/app/views/explicit/documentation/_page.html.erb
+++ b/app/views/explicit/documentation/_page.html.erb
@@ -56,7 +56,7 @@
           Version <%= version %>
         </div>
         <div class="p-1 w-1/2">
-          <%= link_to "https://petstore.swagger.io/?url=#{url_helpers.explicit_documentation_swagger_url(host: request.host)}", target: "_blank", class: "flex items-center justify-center gap-1 text-neutral-900" do %>
+          <%= link_to "https://petstore.swagger.io/?url=#{url_helpers.explicit_documentation_swagger_url(host:)}", target: "_blank", class: "flex items-center justify-center gap-1 text-neutral-900" do %>
             <span>Swagger</span>
 
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">

--- a/lib/explicit/documentation.rb
+++ b/lib/explicit/documentation.rb
@@ -17,7 +17,7 @@ module Explicit::Documentation
 
     engine.routes.draw do
       get "/", to: builder.webpage, as: :explicit_documentation_webpage
-      get "/swagger", to: builder.swagger, as: :explicit_documentation_swagger
+      match "/swagger", to: builder.swagger, as: :explicit_documentation_swagger, via: [:get, :options]
     end
 
     engine

--- a/lib/explicit/documentation/output/webpage.rb
+++ b/lib/explicit/documentation/output/webpage.rb
@@ -8,8 +8,8 @@ module Explicit::Documentation::Output
       @builder = builder
     end
 
-    def call(request)
-      @html ||= render_documentation_page
+    def call(env)
+      @html ||= render_documentation_page(host: env["HTTP_HOST"])
 
       [200, {}, [@html]]
     end
@@ -21,10 +21,11 @@ module Explicit::Documentation::Output
     private
       Eval = ->(value) { value.respond_to?(:call) ? value.call : value }
 
-      def render_documentation_page
+      def render_documentation_page(host:)
         Explicit::ApplicationController.render(
           partial: "explicit/documentation/page",
           locals: {
+            host:,
             url_helpers: @builder.rails_engine.routes.url_helpers,
             page_title: Eval[builder.get_page_title],
             company_logo_url: Eval[builder.get_company_logo_url],


### PR DESCRIPTION
- Add preflight request to /swagger endpoint to fix CORS issues with swagger UI.
- Use same host present in the webpage request instead of the host defined in
  `routes.default_url_options`
